### PR TITLE
refactoring the ios sample

### DIFF
--- a/ios/samples/hello-gltf/hello-gltf/FilamentView/App.cpp
+++ b/ios/samples/hello-gltf/hello-gltf/FilamentView/App.cpp
@@ -150,7 +150,6 @@ void App::setupCamera() {
 }
 
 void App::setupView() {
-    std::cout << "Setting up view with width x height " << width << " x " << height << std::endl;
     view = engine->createView();
     view->setScene(scene);
     view->setCamera(camera);

--- a/ios/samples/hello-gltf/hello-gltf/FilamentView/App.h
+++ b/ios/samples/hello-gltf/hello-gltf/FilamentView/App.h
@@ -45,13 +45,14 @@ namespace gltfio {
 class App {
 public:
 
-    App(void* nativeLayer, uint32_t width, uint32_t height, const utils::Path& resourcePath);
+    App(const utils::Path& resourcePath);
     ~App();
     App(const App&) = delete;
     App& operator=(const App&) = delete;
 
     void render();
     void pan(float deltaX, float deltaY);
+    void bindNativeLayer(void* nativeLayer, uint32_t width, uint32_t height);
 
 private:
 
@@ -60,6 +61,8 @@ private:
     void setupMaterial();
     void setupMesh();
     void setupView();
+    void setupCamera();
+    
 
     void* nativeLayer = nullptr;
     uint32_t width, height;
@@ -86,6 +89,7 @@ private:
     } app;
 
     CameraManipulator cameraManipulator;
+    
 
 };
 

--- a/ios/samples/hello-gltf/hello-gltf/FilamentView/FilamentViewController.mm
+++ b/ios/samples/hello-gltf/hello-gltf/FilamentView/FilamentViewController.mm
@@ -33,10 +33,8 @@
 {
     [super viewDidLoad];
 
-    CGRect nativeBounds = [[UIScreen mainScreen] nativeBounds];
     NSString* resourcePath = [NSBundle mainBundle].bundlePath;
-    app = new App((__bridge void*) self.view.layer, nativeBounds.size.width,
-            nativeBounds.size.height, utils::Path([resourcePath cStringUsingEncoding:NSUTF8StringEncoding]));
+    app = new App(utils::Path([resourcePath cStringUsingEncoding:NSUTF8StringEncoding]));
 
     // Call render 60 times a second.
     displayLink = [CADisplayLink displayLinkWithTarget:self selector:@selector(render)];
@@ -48,6 +46,13 @@
     panRecognizer.minimumNumberOfTouches = 1;
     panRecognizer.maximumNumberOfTouches = 1;
     [self.view addGestureRecognizer:panRecognizer];
+}
+
+- (void)viewWillAppear:(BOOL)animated
+{
+    [super viewWillAppear:animated];
+    CGRect nativeBounds = [[UIScreen mainScreen] nativeBounds];
+    app->bindNativeLayer((__bridge void*)self.view.layer, nativeBounds.size.width, nativeBounds.size.height);
 }
 
 - (void)render


### PR DESCRIPTION
Example demonstrating that we can refactor the filament engine setup into two parts:

1) setup engine and scene (can be done without native layer and swap chain)
2) setup swap chain, view, renderer