### PR TITLE
[gltfio] add params to skip maps

### DIFF
--- a/libs/gltfio/include/gltfio/AssetLoader.h
+++ b/libs/gltfio/include/gltfio/AssetLoader.h
@@ -66,6 +66,9 @@ struct AssetConfiguration {
 
     //! Whether to skip normal maps. Generally not needed for photogrammetry assets
     bool skipNormalMaps = false;
+
+    //! Whether to skip metallic roughness maps. Generally not needed for photogrammetry assets
+    bool skipMetallicRoughnessMaps = false;
 };
 
 /**

--- a/libs/gltfio/include/gltfio/AssetLoader.h
+++ b/libs/gltfio/include/gltfio/AssetLoader.h
@@ -60,6 +60,12 @@ struct AssetConfiguration {
 
     //! Optional default node name for anonymous nodes
     char* defaultNodeName = nullptr;
+
+    //! Whether to skip ambient occlusion maps. Generally not needed for photogrammetry assets
+    bool skipAmbientOcclusionMaps = false;
+
+    //! Whether to skip normal maps. Generally not needed for photogrammetry assets
+    bool skipNormalMaps = false;
 };
 
 /**

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -152,6 +152,10 @@ struct FAssetLoader : public AssetLoader {
     MaterialProvider* mMaterials;
     Engine* mEngine;
 
+    // options applied to assets created by this loader
+    bool mSkipAmbientOcclusionMaps;
+    bool mSkipNormalMaps;
+
     // Transient state used only for the asset currently being loaded:
     FFilamentAsset* mResult;
     const char* mDefaultNodeName;

--- a/libs/gltfio/src/AssetLoader.cpp
+++ b/libs/gltfio/src/AssetLoader.cpp
@@ -1156,7 +1156,6 @@ MaterialInstance* FAssetLoader::createMaterialInstance(const cgltf_data* srcAsse
     }
 
     if (matkey.hasMetallicRoughnessTexture) {
-        printf("Has metallic roughness! \n");
         // The "metallicRoughnessMap" is actually a specular-glossiness map when the extension is
         // enabled. Note that KHR_materials_pbrSpecularGlossiness specifies that diffuseTexture and
         // specularGlossinessTexture are both sRGB, whereas the core glTF spec stipulates that
@@ -1204,8 +1203,6 @@ MaterialInstance* FAssetLoader::createMaterialInstance(const cgltf_data* srcAsse
     }
 
     if (matkey.hasClearCoat) {
-
-        printf("Model has clear coat! \n");
         mi->setParameter("clearCoatFactor", ccConfig.clearcoat_factor);
         mi->setParameter("clearCoatRoughnessFactor", ccConfig.clearcoat_roughness_factor);
 
@@ -1237,7 +1234,6 @@ MaterialInstance* FAssetLoader::createMaterialInstance(const cgltf_data* srcAsse
     }
 
     if (matkey.hasSheen) {
-        printf("Model has sheen! \n");
         const float* s = shConfig.sheen_color_factor;
         mi->setParameter("sheenColorFactor", float3{s[0], s[1], s[2]});
         mi->setParameter("sheenRoughnessFactor", shConfig.sheen_roughness_factor);


### PR DESCRIPTION
Extends the AssetConfiguration for AssetLoader to include flags for not loading maps that are not necessary for photogrammetry assets to save memory and improve performance