### PR TITLE
disable mat opt on metal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -469,7 +469,7 @@ if (FILAMENT_SUPPORTS_VULKAN)
 endif()
 if (FILAMENT_SUPPORTS_METAL)
     set(MATC_API_FLAGS ${MATC_API_FLAGS} -a metal)
-    set(MATC_OPT_FLAGS -gd) # material optimizations causes rendering artifacts on METAL 
+    set(MATC_OPT_FLAGS -g) # material optimizations causes rendering artifacts on METAL
 endif()
 
 # Disable optimizations and enable debug info (preserves names in SPIR-V)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -469,6 +469,7 @@ if (FILAMENT_SUPPORTS_VULKAN)
 endif()
 if (FILAMENT_SUPPORTS_METAL)
     set(MATC_API_FLAGS ${MATC_API_FLAGS} -a metal)
+    set(MATC_OPT_FLAGS -gd) # material optimizations causes rendering artifacts on METAL 
 endif()
 
 # Disable optimizations and enable debug info (preserves names in SPIR-V)


### PR DESCRIPTION
This fixes this issue: https://app.shortcut.com/polycam/story/2043/lingering-render-issues-on-ios

![IMG_96A48CCFDC2A-1](https://user-images.githubusercontent.com/12475454/206035173-d94ec8fe-21d3-4842-a5c4-950972f6a55e.jpeg)


The fix is taken from this tip: https://github.com/google/filament/issues/6344

I am open to alternative ways for setting this flag, I just stuck it into the metal condition