### PR TITLE
Omri/texture scale down

### DIFF
--- a/libs/gltfio/include/gltfio/TextureProvider.h
+++ b/libs/gltfio/include/gltfio/TextureProvider.h
@@ -170,8 +170,9 @@ public:
 /**
  * Creates a simple decoder based on stb_image that can handle "image/png" and "image/jpeg".
  * This works only if your build configuration includes STB.
+ * scaleDownFactor should be 1.0f and higher, for example scaleDownFactor of 4.0f to scale 1024x1024 to 256x256.
  */
-TextureProvider* createStbProvider(filament::Engine* engine);
+TextureProvider* createStbProvider(filament::Engine* engine, float scaleDownFactor = 1.0f);
 
 /**
  * Creates a decoder that can handle certain types of "image/ktx2" content as specified in

--- a/libs/gltfio/include/gltfio/TextureProvider.h
+++ b/libs/gltfio/include/gltfio/TextureProvider.h
@@ -173,7 +173,7 @@ public:
  * Creates a simple decoder based on stb_image that can handle "image/png" and "image/jpeg".
  * This works only if your build configuration includes STB.
  */
-TextureProvider* createStbProvider(filament::Engine* engine, const std::optional<unsigned int> &maxTextureSize = std::optional<uint32_t>());
+TextureProvider* createStbProvider(filament::Engine* engine, const std::optional<unsigned int> &maxTextureSize = std::optional<unsigned int>());
 
 /**
  * Creates a decoder that can handle certain types of "image/ktx2" content as specified in

--- a/libs/gltfio/include/gltfio/TextureProvider.h
+++ b/libs/gltfio/include/gltfio/TextureProvider.h
@@ -20,6 +20,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <optional>
+
 #include <utils/compiler.h>
 #include <utils/BitmaskEnum.h>
 
@@ -170,9 +172,8 @@ public:
 /**
  * Creates a simple decoder based on stb_image that can handle "image/png" and "image/jpeg".
  * This works only if your build configuration includes STB.
- * scaleDownFactor should be 1.0f and higher, for example scaleDownFactor of 4.0f to scale 1024x1024 to 256x256.
  */
-TextureProvider* createStbProvider(filament::Engine* engine, float scaleDownFactor = 1.0f);
+TextureProvider* createStbProvider(filament::Engine* engine, const std::optional<unsigned int> &maxTextureSize = std::optional<uint32_t>());
 
 /**
  * Creates a decoder that can handle certain types of "image/ktx2" content as specified in

--- a/libs/gltfio/src/StbProvider.cpp
+++ b/libs/gltfio/src/StbProvider.cpp
@@ -186,9 +186,11 @@ void StbProvider::updateQueue() {
                 ++mDecodedCount;
                 continue;
             }
-            Texture::PixelBufferDescriptor pbd((uint8_t*) data,
-                    texture->getWidth() * texture->getHeight() * 4, Texture::Format::RGBA,
-                    Texture::Type::UBYTE, [](void* mem, size_t, void*) { stbi_image_free(mem); });
+            const auto textureSize = texture->getWidth() * texture->getHeight() * 4;
+            auto pbd = info->resized ? Texture::PixelBufferDescriptor((uint8_t*)data, textureSize, Texture::Format::RGBA, Texture::Type::UBYTE,
+                                                                      [](void* mem, size_t, void*) { delete[] ((uint8_t*)mem); })
+                                     : Texture::PixelBufferDescriptor((uint8_t*)data, textureSize, Texture::Format::RGBA, Texture::Type::UBYTE,
+                                                                      [](void* mem, size_t, void*) { stbi_image_free(mem); });
             texture->setImage(*mEngine, 0, std::move(pbd));
 
             // Call generateMipmaps unconditionally to fulfill the promise of the TextureProvider

--- a/libs/image/include/image/ImageSampler.h
+++ b/libs/image/include/image/ImageSampler.h
@@ -20,6 +20,8 @@
 #include <image/LinearImage.h>
 
 #include <utils/compiler.h>
+#include <memory>
+#include <cstdint>
 
 namespace image {
 
@@ -158,6 +160,20 @@ uint32_t getMipmapCount(const LinearImage& source);
  */
 UTILS_PUBLIC
 Filter filterFromString(const char* name);
+
+/**
+ * Returns whether simpleScaleDownRgba() is usable on the specified dimensions.
+ */
+bool canSimpleScaleDown(uint32_t sourceWidth, uint32_t sourceHeight, uint32_t destinationWidth, uint32_t destinationHeight);
+
+/**
+ * Scales down a single byte per component RGBA image where each destination pixel corresponds to
+ * a whole number of source pixels on each dimension. canSimpleScaleDown(sourceWidth, sourceHeight, destinationWidth, destinationHeight)
+ * must return true as a precondition.
+ */
+std::unique_ptr<uint8_t[]> simpleScaleDownRgba(
+    const uint8_t *source, uint32_t sourceWidth, uint32_t sourceHeight, uint32_t sourceLineStride,
+    uint32_t destinationWidth, uint32_t destinationHeight, uint32_t destinationLineStride);
 
 } // namespace image
 


### PR DESCRIPTION
Adds an optional scale down factor parameter to `gltfio::createStbProvider()`. When used, scales the down the texture resolution prior to uploading it to the GPU's texture memory. Scale down is accomplished using a pretty fast custom scaling function `image::simpleScaleDownRgba()` whenever possible. This is done as the existing scaling functions in filament use floating point math and are wicked slow and consume a ton of memory. When this is not possible, resorts to using the existing scaling functions as is the case when the source dimension isn't wholly divisible by the destination dimension.