### PR TITLE
Omri/unused textures

### DIFF
--- a/libs/gltfio/src/FilamentAsset.cpp
+++ b/libs/gltfio/src/FilamentAsset.cpp
@@ -79,7 +79,7 @@ FFilamentAsset::~FFilamentAsset() {
         mEngine->destroy(ib);
     }
     for (auto tx : mTextures) {
-        if (UTILS_LIKELY(tx.isOwner)) {
+        if (UTILS_LIKELY(tx.isOwner) && tx.texture != nullptr) {
             mEngine->destroy(tx.texture);
         }
     }

--- a/libs/gltfio/src/ResourceLoader.cpp
+++ b/libs/gltfio/src/ResourceLoader.cpp
@@ -760,6 +760,9 @@ void ResourceLoader::Impl::createTextures(FFilamentAsset* asset, bool async) {
     // Create new texture objects if they are not cached and kick off decoding jobs.
     for (size_t textureIndex = 0, n = asset->mTextures.size(); textureIndex < n; ++textureIndex) {
         FFilamentAsset::TextureInfo& info = asset->mTextures[textureIndex];
+        if(info.bindings.empty()) {
+          continue;
+        }
         auto [texture, cacheResult] = getOrCreateTexture(asset, textureIndex, info.flags);
         if (texture == nullptr) {
             if (cacheResult == CacheResult::NOT_READY) {


### PR DESCRIPTION
Do not load any textures into GPU memory that have no bindings. This is the case when texture use is blocked via the `skipAmbientOcclusionMaps`, `skipNormalMaps` and `skipMetallicRoughnessMaps` options on `gltfio::AssetConfiguration` added by polycam.
Verified on the debugger in polyviewer/mac that this eliminates several calls to `gltfio::TextureProvider::pushTexture()` for the unbound textures.
Updating the polycam repository to this revision of the filament submodule is accomplished in [this PR](https://github.com/PolyCam/polycam/pull/2181).